### PR TITLE
Add lottery prediction UI layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,27 @@ fun `loadUser with valid id returns success state`() = runTest {
 # (Optional) รัน Connected Tests (UI Tests)
 ./gradlew connectedCheck
 ```
+
+---
+
+## 🎲 Lottery Analysis Engine
+
+This project now includes a simple prediction engine located in `co.storylog.pinto.domain.analysis`. It provides functions for:
+
+- Calculating digit frequencies across historical results.
+- Determining hot and cold numbers based on recent draws.
+- Finding the most common two-digit pairs.
+- Generating naive predictions for two and three digit prizes.
+
+Unit tests demonstrating the usage of these functions can be found in `app/src/test/java/co/storylog/pinto/domain/analysis`.
+
+### New Sample Implementation
+
+A simple Compose UI demonstrates a clean separation between layers:
+
+- **Repository** – `FakeLotteryRepository` supplies lottery data.
+- **UseCase** – `GeneratePredictionsUseCase` performs analysis and exposes predictions.
+- **ViewModel** – `LotteryViewModel` holds UI state and triggers the use case.
+- **UI** – `LotteryScreen` renders the predictions using Jetpack Compose.
+
+See `MainActivity` for how these pieces are wired together.

--- a/app/src/main/java/chawan/fame/testmvvm/MainActivity.kt
+++ b/app/src/main/java/chawan/fame/testmvvm/MainActivity.kt
@@ -1,12 +1,25 @@
 package chawan.fame.testmvvm
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import co.storylog.pinto.data.repository.FakeLotteryRepository
+import co.storylog.pinto.domain.usecase.GeneratePredictionsUseCase
+import co.storylog.pinto.presentation.ui.LotteryScreen
+import co.storylog.pinto.presentation.viewmodel.LotteryViewModel
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
+
+    private val viewModel by lazy {
+        val repository = FakeLotteryRepository()
+        val useCase = GeneratePredictionsUseCase(repository)
+        LotteryViewModel(useCase)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContent {
+            LotteryScreen(viewModel)
+        }
     }
 }

--- a/app/src/main/java/co/storylog/pinto/data/repository/FakeLotteryRepository.kt
+++ b/app/src/main/java/co/storylog/pinto/data/repository/FakeLotteryRepository.kt
@@ -1,0 +1,17 @@
+package co.storylog.pinto.data.repository
+
+import co.storylog.pinto.domain.analysis.LotteryResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeLotteryRepository : LotteryRepository {
+    override fun getResults(): Flow<List<LotteryResult>> = flow {
+        val data = listOf(
+            LotteryResult("2024-06-01", "12", listOf("123", "456")),
+            LotteryResult("2024-05-16", "34", listOf("234", "567")),
+            LotteryResult("2024-05-01", "12", listOf("789", "123")),
+            LotteryResult("2024-04-16", "56", listOf("234", "890"))
+        )
+        emit(data)
+    }
+}

--- a/app/src/main/java/co/storylog/pinto/data/repository/LotteryRepository.kt
+++ b/app/src/main/java/co/storylog/pinto/data/repository/LotteryRepository.kt
@@ -1,0 +1,8 @@
+package co.storylog.pinto.data.repository
+
+import co.storylog.pinto.domain.analysis.LotteryResult
+import kotlinx.coroutines.flow.Flow
+
+interface LotteryRepository {
+    fun getResults(): Flow<List<LotteryResult>>
+}

--- a/app/src/main/java/co/storylog/pinto/domain/analysis/LotteryAnalysis.kt
+++ b/app/src/main/java/co/storylog/pinto/domain/analysis/LotteryAnalysis.kt
@@ -1,0 +1,91 @@
+package co.storylog.pinto.domain.analysis
+
+/**
+ * Data model representing a lottery result. Only the last two-digit and
+ * last three-digit prizes are captured for simplicity.
+ */
+data class LotteryResult(
+    val drawDate: String,
+    val lastTwoDigits: String,
+    val lastThreeDigits: List<String>
+)
+
+/**
+ * Counts digit frequency (0-9) from the given results.
+ */
+fun calculateDigitFrequency(results: List<LotteryResult>): Map<Int, Int> {
+    val counts = IntArray(10)
+    results.forEach { result ->
+        (listOf(result.lastTwoDigits) + result.lastThreeDigits).forEach { number ->
+            number.forEach { char ->
+                val digit = char.digitToIntOrNull() ?: return@forEach
+                counts[digit]++
+            }
+        }
+    }
+    return counts.mapIndexed { index, value -> index to value }.toMap()
+}
+
+/**
+ * Returns digits ordered by descending frequency within the last [recentDraws]
+ * results to identify "hot" numbers.
+ */
+fun getHotNumbers(results: List<LotteryResult>, recentDraws: Int = 10): List<Int> {
+    val subset = results.takeLast(recentDraws)
+    return calculateDigitFrequency(subset)
+        .toList()
+        .sortedByDescending { it.second }
+        .map { it.first }
+}
+
+/**
+ * Returns digits ordered by ascending frequency within the last [recentDraws]
+ * results to identify "cold" numbers.
+ */
+fun getColdNumbers(results: List<LotteryResult>, recentDraws: Int = 10): List<Int> {
+    val subset = results.takeLast(recentDraws)
+    return calculateDigitFrequency(subset)
+        .toList()
+        .sortedBy { it.second }
+        .map { it.first }
+}
+
+/**
+ * Calculates the most common two-digit pairs from all results.
+ */
+fun getTopPairs(results: List<LotteryResult>, top: Int = 5): List<String> {
+    val pairCount = mutableMapOf<String, Int>()
+    results.forEach { result ->
+        val pair = result.lastTwoDigits
+        pairCount[pair] = pairCount.getOrDefault(pair, 0) + 1
+    }
+    return pairCount
+        .toList()
+        .sortedByDescending { it.second }
+        .take(top)
+        .map { it.first }
+}
+
+/**
+ * Simple prediction engine combining the above analyses to provide candidate
+ * two-digit and three-digit numbers.
+ */
+object LotteryPredictionEngine {
+    fun predictTwoDigit(results: List<LotteryResult>): List<String> {
+        // Use top appearing pairs as naive prediction
+        return getTopPairs(results)
+    }
+
+    fun predictThreeDigit(results: List<LotteryResult>): List<String> {
+        val freqMap = mutableMapOf<String, Int>()
+        results.flatMap { it.lastThreeDigits }.forEach { num ->
+            freqMap[num] = freqMap.getOrDefault(num, 0) + 1
+        }
+        return freqMap
+            .toList()
+            .sortedByDescending { it.second }
+            .take(5)
+            .map { it.first }
+    }
+}
+

--- a/app/src/main/java/co/storylog/pinto/domain/usecase/GeneratePredictionsUseCase.kt
+++ b/app/src/main/java/co/storylog/pinto/domain/usecase/GeneratePredictionsUseCase.kt
@@ -1,0 +1,24 @@
+package co.storylog.pinto.domain.usecase
+
+import co.storylog.pinto.data.repository.LotteryRepository
+import co.storylog.pinto.domain.analysis.LotteryPredictionEngine
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class GeneratePredictionsUseCase(
+    private val repository: LotteryRepository
+) {
+    operator fun invoke(): Flow<PredictionResult> {
+        return repository.getResults().map { results ->
+            PredictionResult(
+                twoDigits = LotteryPredictionEngine.predictTwoDigit(results),
+                threeDigits = LotteryPredictionEngine.predictThreeDigit(results)
+            )
+        }
+    }
+}
+
+data class PredictionResult(
+    val twoDigits: List<String>,
+    val threeDigits: List<String>
+)

--- a/app/src/main/java/co/storylog/pinto/presentation/ui/LotteryScreen.kt
+++ b/app/src/main/java/co/storylog/pinto/presentation/ui/LotteryScreen.kt
@@ -1,0 +1,61 @@
+package co.storylog.pinto.presentation.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.tooling.preview.Preview
+import co.storylog.pinto.presentation.viewmodel.LotteryUiState
+import co.storylog.pinto.presentation.viewmodel.LotteryViewModel
+
+@Composable
+fun LotteryScreen(viewModel: LotteryViewModel) {
+    val state = viewModel.state.collectAsState()
+    when (val uiState = state.value) {
+        LotteryUiState.Loading -> Text("Loading...")
+        is LotteryUiState.Success -> LotteryContent(
+            twoDigits = uiState.twoDigits,
+            threeDigits = uiState.threeDigits,
+            onRefresh = { viewModel.loadPredictions() }
+        )
+    }
+}
+
+@Composable
+private fun LotteryContent(
+    twoDigits: List<String>,
+    threeDigits: List<String>,
+    onRefresh: () -> Unit
+) {
+    Column {
+        Text("Two-digit predictions:", style = MaterialTheme.typography.titleMedium)
+        LazyColumn {
+            items(twoDigits) { item ->
+                Text(text = item)
+            }
+        }
+        Text("Three-digit predictions:", style = MaterialTheme.typography.titleMedium)
+        LazyColumn {
+            items(threeDigits) { item ->
+                Text(text = item)
+            }
+        }
+        Button(onClick = onRefresh) {
+            Text("Refresh")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLotteryContent() {
+    LotteryContent(
+        twoDigits = listOf("12", "34"),
+        threeDigits = listOf("123", "234"),
+        onRefresh = {}
+    )
+}

--- a/app/src/main/java/co/storylog/pinto/presentation/viewmodel/LotteryViewModel.kt
+++ b/app/src/main/java/co/storylog/pinto/presentation/viewmodel/LotteryViewModel.kt
@@ -1,0 +1,38 @@
+package co.storylog.pinto.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.storylog.pinto.domain.usecase.GeneratePredictionsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class LotteryViewModel(
+    private val generatePredictionsUseCase: GeneratePredictionsUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<LotteryUiState>(LotteryUiState.Loading)
+    val state: StateFlow<LotteryUiState> = _state.asStateFlow()
+
+    init {
+        loadPredictions()
+    }
+
+    fun loadPredictions() {
+        viewModelScope.launch {
+            generatePredictionsUseCase()
+                .collect { result ->
+                    _state.value = LotteryUiState.Success(result.twoDigits, result.threeDigits)
+                }
+        }
+    }
+}
+
+sealed interface LotteryUiState {
+    object Loading : LotteryUiState
+    data class Success(
+        val twoDigits: List<String>,
+        val threeDigits: List<String>
+    ) : LotteryUiState
+}

--- a/app/src/test/java/co/storylog/pinto/domain/analysis/LotteryAnalysisTest.kt
+++ b/app/src/test/java/co/storylog/pinto/domain/analysis/LotteryAnalysisTest.kt
@@ -1,0 +1,44 @@
+package co.storylog.pinto.domain.analysis
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LotteryAnalysisTest {
+
+    private val sampleData = listOf(
+        LotteryResult("2024-06-01", "12", listOf("123", "456")),
+        LotteryResult("2024-05-16", "34", listOf("234", "567")),
+        LotteryResult("2024-05-01", "12", listOf("789", "123")),
+        LotteryResult("2024-04-16", "56", listOf("234", "890"))
+    )
+
+    @Test
+    fun `calculateDigitFrequency returns correct counts`() {
+        val freq = calculateDigitFrequency(sampleData)
+        assertEquals(3, freq[1])
+        assertEquals(4, freq[2])
+        assertEquals(2, freq[3])
+    }
+
+    @Test
+    fun `getHotNumbers returns digits sorted by frequency`() {
+        val hot = getHotNumbers(sampleData, recentDraws = 4)
+        assertEquals(10, hot.size)
+        // First digit should be '2' because it appears most often in sampleData
+        assertEquals(2, hot.first())
+    }
+
+    @Test
+    fun `getTopPairs returns most frequent pairs`() {
+        val pairs = getTopPairs(sampleData, top = 2)
+        assertEquals(listOf("12", "34"), pairs)
+    }
+
+    @Test
+    fun `prediction engine returns top numbers`() {
+        val twoDigit = LotteryPredictionEngine.predictTwoDigit(sampleData)
+        assertEquals("12", twoDigit.first())
+        val threeDigit = LotteryPredictionEngine.predictThreeDigit(sampleData)
+        assertEquals("234", threeDigit.first())
+    }
+}

--- a/app/src/test/java/co/storylog/pinto/domain/usecase/GeneratePredictionsUseCaseTest.kt
+++ b/app/src/test/java/co/storylog/pinto/domain/usecase/GeneratePredictionsUseCaseTest.kt
@@ -1,0 +1,21 @@
+package co.storylog.pinto.domain.usecase
+
+import co.storylog.pinto.data.repository.FakeLotteryRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GeneratePredictionsUseCaseTest {
+
+    @Test
+    fun `invoke returns predictions`() = runTest {
+        val repo = FakeLotteryRepository()
+        val useCase = GeneratePredictionsUseCase(repo)
+
+        val result = useCase().first()
+
+        assertEquals("12", result.twoDigits.first())
+        assertEquals("234", result.threeDigits.first())
+    }
+}


### PR DESCRIPTION
## Summary
- introduce repository/usecase/viewmodel layers for lottery predictions
- build simple Jetpack Compose screen displaying predictions
- wire up ViewModel in `MainActivity`
- document new layered sample in README
- add a unit test for `GeneratePredictionsUseCase`

## Testing
- `./gradlew test` *(fails: Could not determine java version from '21.0.7')*
- `./gradlew check` *(fails: Could not determine java version from '21.0.7')*

------
https://chatgpt.com/codex/tasks/task_e_6849711264fc8326b9afb7f104ed256c