### PR TITLE
Add lottery predictor with MVVM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
-
+apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
     defaultConfig {
         applicationId "chawan.fame.testmvvm"
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -20,14 +20,37 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.1'
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation platform('androidx.compose:compose-bom:2023.08.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.activity:activity-compose:1.7.2'
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'androidx.room:room-runtime:2.6.1'
+    kapt 'androidx.room:room-compiler:2.6.1'
+    implementation 'androidx.room:room-ktx:2.6.1'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'io.mockk:mockk:1.13.7'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/java/chawan/fame/lottery/data/local/LotteryDatabase.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/local/LotteryDatabase.kt
@@ -1,0 +1,9 @@
+package chawan.fame.lottery.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [LotteryResultEntity::class], version = 1)
+abstract class LotteryDatabase : RoomDatabase() {
+    abstract fun lotteryResultDao(): LotteryResultDao
+}

--- a/app/src/main/java/chawan/fame/lottery/data/local/LotteryResultDao.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/local/LotteryResultDao.kt
@@ -1,0 +1,16 @@
+package chawan.fame.lottery.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LotteryResultDao {
+    @Query("SELECT * FROM ${LotteryResultEntity.TABLE_NAME}")
+    fun getAll(): Flow<List<LotteryResultEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<LotteryResultEntity>)
+}

--- a/app/src/main/java/chawan/fame/lottery/data/local/LotteryResultEntity.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/local/LotteryResultEntity.kt
@@ -1,0 +1,26 @@
+package chawan.fame.lottery.data.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = LotteryResultEntity.TABLE_NAME)
+data class LotteryResultEntity(
+    @PrimaryKey
+    @ColumnInfo(name = COLUMN_ID)
+    val id: Long,
+    @ColumnInfo(name = COLUMN_DRAW_DATE)
+    val drawDate: String,
+    @ColumnInfo(name = COLUMN_LAST2)
+    val last2: String,
+    @ColumnInfo(name = COLUMN_LAST3)
+    val last3: String
+) {
+    companion object {
+        const val TABLE_NAME = "lottery_result"
+        const val COLUMN_ID = "id"
+        const val COLUMN_DRAW_DATE = "draw_date"
+        const val COLUMN_LAST2 = "last2"
+        const val COLUMN_LAST3 = "last3"
+    }
+}

--- a/app/src/main/java/chawan/fame/lottery/data/remote/LotteryApiService.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/remote/LotteryApiService.kt
@@ -1,0 +1,18 @@
+package chawan.fame.lottery.data.remote
+
+import retrofit2.http.GET
+
+/**
+ * API service for lottery results
+ */
+interface LotteryApiService {
+    @GET("lottery/history.json")
+    suspend fun getLotteryHistory(): List<LotteryResultDto>
+}
+
+data class LotteryResultDto(
+    val id: Long,
+    val drawDate: String,
+    val last2: String,
+    val last3: String
+)

--- a/app/src/main/java/chawan/fame/lottery/data/repository/LotteryRepository.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/repository/LotteryRepository.kt
@@ -1,0 +1,9 @@
+package chawan.fame.lottery.data.repository
+
+import chawan.fame.lottery.data.local.LotteryResultEntity
+import kotlinx.coroutines.flow.Flow
+
+interface LotteryRepository {
+    fun getHistory(): Flow<List<LotteryResultEntity>>
+    suspend fun fetchAndCacheHistory()
+}

--- a/app/src/main/java/chawan/fame/lottery/data/repository/LotteryRepositoryImpl.kt
+++ b/app/src/main/java/chawan/fame/lottery/data/repository/LotteryRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package chawan.fame.lottery.data.repository
+
+import chawan.fame.lottery.data.local.LotteryDatabase
+import chawan.fame.lottery.data.local.LotteryResultEntity
+import chawan.fame.lottery.data.remote.LotteryApiService
+import kotlinx.coroutines.flow.Flow
+
+class LotteryRepositoryImpl(
+    private val api: LotteryApiService,
+    private val db: LotteryDatabase
+) : LotteryRepository {
+
+    override fun getHistory(): Flow<List<LotteryResultEntity>> =
+        db.lotteryResultDao().getAll()
+
+    override suspend fun fetchAndCacheHistory() {
+        val remote = api.getLotteryHistory()
+        val entities = remote.map {
+            LotteryResultEntity(
+                id = it.id,
+                drawDate = it.drawDate,
+                last2 = it.last2,
+                last3 = it.last3
+            )
+        }
+        db.lotteryResultDao().insertAll(entities)
+    }
+}

--- a/app/src/main/java/chawan/fame/lottery/domain/usecases/PredictLotteryUseCase.kt
+++ b/app/src/main/java/chawan/fame/lottery/domain/usecases/PredictLotteryUseCase.kt
@@ -1,0 +1,18 @@
+package chawan.fame.lottery.domain.usecases
+
+import chawan.fame.lottery.data.repository.LotteryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class PredictLotteryUseCase(private val repository: LotteryRepository) {
+    /**
+     * Predict next 2 and 3 digit numbers based on most frequent historical values.
+     */
+    operator fun invoke(): Flow<Prediction> = repository.getHistory().map { list ->
+        val last2 = list.groupingBy { it.last2 }.eachCount().maxByOrNull { it.value }?.key ?: "--"
+        val last3 = list.groupingBy { it.last3 }.eachCount().maxByOrNull { it.value }?.key ?: "---"
+        Prediction(last2, last3)
+    }
+}
+
+data class Prediction(val last2: String, val last3: String)

--- a/app/src/main/java/chawan/fame/lottery/presentation/model/LotteryUiModel.kt
+++ b/app/src/main/java/chawan/fame/lottery/presentation/model/LotteryUiModel.kt
@@ -1,0 +1,6 @@
+package chawan.fame.lottery.presentation.model
+
+data class LotteryUiModel(
+    val predictedLast2: String,
+    val predictedLast3: String
+)

--- a/app/src/main/java/chawan/fame/lottery/presentation/ui/LotteryScreen.kt
+++ b/app/src/main/java/chawan/fame/lottery/presentation/ui/LotteryScreen.kt
@@ -1,0 +1,41 @@
+package chawan.fame.lottery.presentation.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import chawan.fame.lottery.presentation.viewmodel.LotteryUiState
+import chawan.fame.lottery.presentation.viewmodel.LotteryViewModel
+
+@Composable
+fun LotteryScreen(viewModel: LotteryViewModel) {
+    LaunchedEffect(Unit) { viewModel.loadPrediction() }
+    val uiState by viewModel.uiState.collectAsState()
+    LotteryContent(uiState)
+}
+
+@Composable
+private fun LotteryContent(state: LotteryUiState) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        when (state) {
+            LotteryUiState.Loading -> Text("Loading...", style = MaterialTheme.typography.bodyLarge)
+            is LotteryUiState.Success -> {
+                val data = state.data
+                Text("Predicted Last 2 digits: ${'$'}{data.predictedLast2}")
+                Text("Predicted Last 3 digits: ${'$'}{data.predictedLast3}")
+            }
+            is LotteryUiState.Error -> Text("Error: ${'$'}{state.message}")
+        }
+    }
+}

--- a/app/src/main/java/chawan/fame/lottery/presentation/viewmodel/LotteryViewModel.kt
+++ b/app/src/main/java/chawan/fame/lottery/presentation/viewmodel/LotteryViewModel.kt
@@ -1,0 +1,41 @@
+package chawan.fame.lottery.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chawan.fame.lottery.domain.usecases.PredictLotteryUseCase
+import chawan.fame.lottery.presentation.model.LotteryUiModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface LotteryUiState {
+    object Loading : LotteryUiState
+    data class Success(val data: LotteryUiModel) : LotteryUiState
+    data class Error(val message: String) : LotteryUiState
+}
+
+class LotteryViewModel(
+    private val predictLotteryUseCase: PredictLotteryUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<LotteryUiState>(LotteryUiState.Loading)
+    val uiState: StateFlow<LotteryUiState> = _uiState.asStateFlow()
+
+    fun loadPrediction() {
+        viewModelScope.launch {
+            try {
+                predictLotteryUseCase().collect { prediction ->
+                    _uiState.value = LotteryUiState.Success(
+                        LotteryUiModel(
+                            prediction.last2,
+                            prediction.last3
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = LotteryUiState.Error(e.message ?: "Unknown")
+            }
+        }
+    }
+}

--- a/app/src/main/java/chawan/fame/testmvvm/MainActivity.kt
+++ b/app/src/main/java/chawan/fame/testmvvm/MainActivity.kt
@@ -1,12 +1,27 @@
 package chawan.fame.testmvvm
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import chawan.fame.lottery.domain.usecases.PredictLotteryUseCase
+import chawan.fame.lottery.presentation.ui.LotteryScreen
+import chawan.fame.lottery.presentation.viewmodel.LotteryViewModel
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        // In real project use DI for viewModel and repository
+        val viewModel = LotteryViewModel(PredictLotteryUseCase(object : chawan.fame.lottery.data.repository.LotteryRepository {
+            override fun getHistory() = kotlinx.coroutines.flow.flow { emit(emptyList<chawan.fame.lottery.data.local.LotteryResultEntity>()) }
+            override suspend fun fetchAndCacheHistory() {}
+        }))
+
+        setContent {
+            MaterialTheme {
+                LotteryScreen(viewModel)
+            }
+        }
     }
 }

--- a/app/src/test/java/chawan/fame/lottery/domain/usecases/PredictLotteryUseCaseTest.kt
+++ b/app/src/test/java/chawan/fame/lottery/domain/usecases/PredictLotteryUseCaseTest.kt
@@ -1,0 +1,33 @@
+package chawan.fame.lottery.domain.usecases
+
+import chawan.fame.lottery.data.local.LotteryResultEntity
+import chawan.fame.lottery.data.repository.LotteryRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PredictLotteryUseCaseTest {
+
+    @Test
+    fun `invoke returns most frequent digits`() = runTest {
+        val repo = mockk<LotteryRepository>()
+        coEvery { repo.getHistory() } returns flowOf(
+            listOf(
+                LotteryResultEntity(1, "2024-01-01", "12", "123"),
+                LotteryResultEntity(2, "2024-02-01", "12", "999"),
+                LotteryResultEntity(3, "2024-03-01", "34", "123")
+            )
+        )
+        val useCase = PredictLotteryUseCase(repo)
+
+        val result = useCase().first()
+        assertEquals("12", result.last2)
+        assertEquals("123", result.last3)
+    }
+}

--- a/app/src/test/java/chawan/fame/lottery/presentation/LotteryViewModelTest.kt
+++ b/app/src/test/java/chawan/fame/lottery/presentation/LotteryViewModelTest.kt
@@ -1,0 +1,28 @@
+package chawan.fame.lottery.presentation
+
+import chawan.fame.lottery.domain.usecases.PredictLotteryUseCase
+import chawan.fame.lottery.domain.usecases.Prediction
+import chawan.fame.lottery.presentation.viewmodel.LotteryUiState
+import chawan.fame.lottery.presentation.viewmodel.LotteryViewModel
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LotteryViewModelTest {
+
+    @Test
+    fun `loadPrediction emits success state`() = runTest {
+        val useCase = mockk<PredictLotteryUseCase>()
+        coEvery { useCase.invoke() } returns flowOf(Prediction("11", "111"))
+        val viewModel = LotteryViewModel(useCase)
+
+        viewModel.loadPrediction()
+
+        assertTrue(viewModel.uiState.value is LotteryUiState.Success)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- upgrade gradle wrapper and add Compose/Room/Retrofit dependencies
- implement repository, Room DB, and Retrofit service for lottery results
- implement use case for digit prediction
- add ViewModel and Compose UI
- rewrite MainActivity to host Compose screen
- provide unit tests for use case and ViewModel

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*
- `./gradlew check` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68497500108c8326b34d9b344a297302